### PR TITLE
build kanto suite-connector and service configuration, add README

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "suite-connector"]
+	path = suite-connector
+	url = https://github.com/eclipse-kanto/suite-connector.git

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,13 +1,33 @@
+import("//build/ohos.gni")
 
-action("suite-connector") {
+action("build-suite-connector") {
     script = "BUILD.py"
-    outputs = ["$target_out_dir/suite-connector"]
     outputPath = rebase_path("$target_out_dir")
     inputPath = rebase_path("./suite-connector/cmd/connector")
-    args = ["--target-os=linux", "--target-arch=$target_cpu", "--output=$outputPath", "--input=$inputPath", "--result=suite-connector"]
+    resultName = "suite-connector"
+    args = ["--target-os=linux", "--target-arch=$target_cpu", "--output=$outputPath", "--input=$inputPath", "--result=$resultName"]
+    outputs = ["$target_out_dir/${resultName}"]
 }
 
-copy("iothub-crt") {
+copy("copy-iothub-crt") {
     sources = ["./suite-connector/cmd/connector/iothub.crt"]
     outputs = ["$target_out_dir/iothub.crt"]
 }
+
+ohos_prebuilt_executable("suite-connector") {
+    install_enable = true
+    deps = ["//third_party/kanto:build-suite-connector"]
+    part_name = "kanto"
+    subsystem_name = "thirdparty"
+    source = "$target_out_dir/suite-connector"
+}
+
+ohos_prebuilt_etc("iothub-crt") {
+    install_enable = true
+    deps = ["//third_party/kanto:copy-iothub-crt"]
+    part_name = "kanto"
+    subsystem_name = "thirdparty"
+    source = "$target_out_dir/iothub.crt"
+    relative_install_dir = "suite-connector"
+}
+

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,13 @@
+
+action("suite-connector") {
+    script = "BUILD.py"
+    outputs = ["$target_out_dir/suite-connector"]
+    outputPath = rebase_path("$target_out_dir")
+    inputPath = rebase_path("./suite-connector/cmd/connector")
+    args = ["--target-os=linux", "--target-arch=$target_cpu", "--output=$outputPath", "--input=$inputPath", "--result=suite-connector"]
+}
+
+copy("iothub-crt") {
+    sources = ["./suite-connector/cmd/connector/iothub.crt"]
+    outputs = ["$target_out_dir/iothub.crt"]
+}

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -31,3 +31,18 @@ ohos_prebuilt_etc("iothub-crt") {
     relative_install_dir = "suite-connector"
 }
 
+ohos_prebuilt_etc("config.json") {
+    install_enable = true
+    part_name = "kanto"
+    subsystem_name = "thirdparty"
+    source = "init/config.json"
+    relative_install_dir = "suite-connector"
+}
+
+ohos_prebuilt_etc("kanto_init") {
+  source = "init/kanto.cfg"
+  deps = [":config.json"]
+  relative_install_dir = "init"
+  part_name = "kanto"
+  subsystem_name = "thirdparty"
+}

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -39,9 +39,16 @@ ohos_prebuilt_etc("config.json") {
     relative_install_dir = "suite-connector"
 }
 
+ohos_prebuilt_etc("etc_hosts") {
+    install_enable = true
+    part_name = "kanto"
+    subsystem_name = "thirdparty"
+    source = "init/hosts"
+}
+
 ohos_prebuilt_etc("kanto_init") {
   source = "init/kanto.cfg"
-  deps = [":config.json"]
+  deps = [":config.json", ":etc_hosts"]
   relative_install_dir = "init"
   part_name = "kanto"
   subsystem_name = "thirdparty"

--- a/BUILD.py
+++ b/BUILD.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import subprocess
+import os
+import sys 
+import argparse
+
+   
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--target-os', help='Target os')
+    parser.add_argument('--target-arch', help='Target architecture')
+    parser.add_argument('--output', help='Where the result binary should be moved')
+    parser.add_argument('--input', help='The build folder')
+    parser.add_argument('--result', help="The name of the produced binary")
+    options = parser.parse_args()
+
+    with open(f'{options.output}/log.txt', 'w') as out:
+        os.chdir(options.input)
+        build_command = f"GOOS={options.target_os} GOARCH={options.target_arch} GOFLAGS=-buildvcs=false go build -o {options.result} -v"
+        subprocess.call(build_command, stdout=out, stderr=out, shell=True)
+        subprocess.call(["mv", options.result, options.output])
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM swr.cn-south-1.myhuaweicloud.com/openharmony-docker/docker_oh_standard:3.2
+
+RUN curl -L -s https://go.dev/dl/go1.21.6.linux-amd64.tar.gz | tar -v -C /usr/local -xz
+
+ENV PATH $PATH:/usr/local/go/bin

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # third_party_kanto
+This application aims to demonstrate how kanto components can be built using gn. 
+Of course building go applications using this tooling does not bring any benefits 
+on its own. This approach can be used to integrate these components in existing builds.
+
+## Integrate into Oniro-OpenHarmony build system
+- First of all, obtain the source code following [Oniro docs](https://docs.oniroproject.org/quick-build.html#obtaining-the-source-code).
+- Secondly, clone this repository into `//third_party/kanto`
+
+```console
+$ git clone --recurse-submodules  https://github.com/frankplus/third_party_kanto.git ./third_party/kanto
+```
+
+- add kanto component into the thirdparty subsystem by modifying `//productdefine/common/inherit/rich.json`
+
+```diff
+diff --git a/inherit/rich.json b/inherit/rich.json
+index 255af7f..0075201 100644
+--- a/inherit/rich.json
++++ b/inherit/rich.json
+@@ -947,12 +947,16 @@
+     {
+       "subsystem": "thirdparty",
+       "components": [
+         {
+           "component": "musl",
+           "features": []
++        },
++        {
++          "component": "kanto",
++          "features": []
+         }
+       ]
+     },
+     {
+       "subsystem": "hdf",
+       "components": [
+```
+
+- build a new Docker image from the Dockerfile which, starting from OpenHarmony docker image, is adding golang. Go is required to build kanto suite connector.
+
+```console
+docker build -t docker_oniro ./third_party/kanto
+```
+
+- run the newly built docker image to build Oniro with kanto integrated
+
+```console
+docker run -it -v $(pwd):/home/openharmony docker_oniro
+```
+
+- Inside the Docker instance, set the target device for the build
+
+```console
+./build.sh --product-name rk3568 --ccache
+```
+
+- You will find the build artifacts such as `suite-connector` binary
+in the directory `//out/rk3568/obj/third_party/kanto`

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Before proceeding, ensure you have obtained the Oniro-OpenHarmony source code as
 Clone the Kanto and Mosquitto repositories into the `//third_party` directory to incorporate them into the Oniro-OpenHarmony system:
 
 ```console
-$ git clone --recurse-submodules  https://github.com/frankplus/third_party_kanto.git ./third_party/kanto
-$ git clone --recurse-submodules  https://github.com/frankplus/third_party_mosquitto.git ./third_party/mosquitto
+$ git clone --recurse-submodules  https://github.com/eclipse-oniro4openharmony/third_party_kanto.git ./third_party/kanto
+$ git clone --recurse-submodules  https://github.com/eclipse-oniro4openharmony/third_party_mosquitto.git ./third_party/mosquitto
 ```
 
 ### Modifying Configuration Files
@@ -41,23 +41,34 @@ index 255af7f..e8ff335 100644
 ```
 
 ### Adjusting Security Settings
-Currently, Oniro-OpenHarmony does not natively support third-party services such as Kanto and Mosquitto. As a temporary measure, disable certain security features by modifying the `//vendor/hihope/rk3568/config.json` file.
 
-```diff
-diff --git a/rk3568/config.json b/rk3568/config.json
-index ea2d588..b6a8dc0 100755
---- a/rk3568/config.json
-+++ b/rk3568/config.json
-@@ -9,7 +9,7 @@
-   "api_version": 8,
-   "enable_ramdisk": true,
-   "enable_absystem": false,
--  "build_selinux": true,
-+  "build_selinux": false,
-   "build_seccomp": true,
-   "inherit": [ "productdefine/common/inherit/rich.json", "productdefine/common/inherit/chipset_common.json" ],
-   "subsystems": [
-```
+To run Kanto and Mosquitto services properly in Oniro-OpenHarmony, you need to adjust the security settings. There are two ways to do this:
+
+1. **Apply a SELinux Policy Patch:** This is the recommended method to ensure services run smoothly. Apply the `ohos_policy-add-selinux-policy.patch` to the `base/security/selinux_adapter` directory using the following command:
+
+    ```console
+    git apply --directory=base/security/selinux_adapter ohos_policy-add-selinux-policy.patch
+    ```
+
+2. **Disable SELinux:** As a quicker, but less secure option, you can disable SELinux. This method is only suggested for testing or development environments. To disable, change the `build_selinux` setting from `true` to `false` in the `//vendor/hihope/rk3568/config.json` file:
+
+    ```diff
+    diff --git a/rk3568/config.json b/rk3568/config.json
+    index ea2d588..b6a8dc0 100755
+    --- a/rk3568/config.json
+    +++ b/rk3568/config.json
+    @@ -9,7 +9,7 @@
+      "api_version": 8,
+      "enable_ramdisk": true,
+      "enable_absystem": false,
+    -  "build_selinux": true,
+    +  "build_selinux": false,
+      "build_seccomp": true,
+      "inherit": [ "productdefine/common/inherit/rich.json", "productdefine/common/inherit/chipset_common.json" ],
+      "subsystems": [
+    ```
+
+Choose the method that best fits your security needs and development stage. Applying the patch is safer but disabling SELinux can be a quick way to test functionality.
 
 ### Configuring Kanto for Backend Connection
 Adjust the Kanto configuration by editing the file at `//third_party/kanto/init/config.json`. This setup is crucial for linking your device with a Kanto backend. For instance, if you're utilizing the Eclipse Hono sandbox, your `config.json` could be structured as follows:

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # third_party_kanto
-This application aims to demonstrate how kanto components can be built using gn. 
-Of course building go applications using this tooling does not bring any benefits 
-on its own. This approach can be used to integrate these components in existing builds.
 
-## Integrate into Oniro-OpenHarmony build system
-- First of all, obtain the source code following [Oniro docs](https://docs.oniroproject.org/quick-build.html#obtaining-the-source-code).
-- Secondly, clone this repository into `//third_party/kanto`
+This project outlines the process for integrating third-party services, specifically Kanto and Mosquitto, into the Oniro-OpenHarmony build system. By following these instructions, developers can include these components into their Oniro-OpenHarmony environment, enhancing the system's capabilities with Kanto's suite connector and Mosquitto's message broker functionalities.
+
+## Prerequisites
+Before proceeding, ensure you have obtained the Oniro-OpenHarmony source code as per the [Oniro documentation](https://docs.oniroproject.org/quick-build.html#obtaining-the-source-code).
+
+## Integration Steps
+### Cloning Repositories
+Clone the Kanto and Mosquitto repositories into the `//third_party` directory to incorporate them into the Oniro-OpenHarmony system:
 
 ```console
 $ git clone --recurse-submodules  https://github.com/frankplus/third_party_kanto.git ./third_party/kanto
+$ git clone --recurse-submodules  https://github.com/frankplus/third_party_mosquitto.git ./third_party/mosquitto
 ```
 
-- add kanto component into the thirdparty subsystem by modifying `//productdefine/common/inherit/rich.json`
+### Modifying Configuration Files
+Add Kanto and Mosquitto components to the "thirdparty" subsystem by editing the `//productdefine/common/inherit/rich.json` file. This involves appending their configurations to the subsystem component list.
 
 ```diff
 diff --git a/inherit/rich.json b/inherit/rich.json
-index 255af7f..0075201 100644
+index 255af7f..e8ff335 100644
 --- a/inherit/rich.json
 +++ b/inherit/rich.json
-@@ -947,12 +947,16 @@
-     {
-       "subsystem": "thirdparty",
-       "components": [
+@@ -950,6 +950,14 @@
          {
            "component": "musl",
            "features": []
@@ -29,31 +30,77 @@ index 255af7f..0075201 100644
 +        {
 +          "component": "kanto",
 +          "features": []
++        },
++        {
++          "component": "mosquitto",
++          "features": []
          }
        ]
      },
-     {
-       "subsystem": "hdf",
-       "components": [
+
 ```
 
-- build a new Docker image from the Dockerfile which, starting from OpenHarmony docker image, is adding golang. Go is required to build kanto suite connector.
+### Adjusting Security Settings
+Currently, Oniro-OpenHarmony does not natively support third-party services such as Kanto and Mosquitto. As a temporary measure, disable certain security features by modifying the `//vendor/hihope/rk3568/config.json` file.
+
+```diff
+diff --git a/rk3568/config.json b/rk3568/config.json
+index ea2d588..b6a8dc0 100755
+--- a/rk3568/config.json
++++ b/rk3568/config.json
+@@ -9,7 +9,7 @@
+   "api_version": 8,
+   "enable_ramdisk": true,
+   "enable_absystem": false,
+-  "build_selinux": true,
++  "build_selinux": false,
+   "build_seccomp": true,
+   "inherit": [ "productdefine/common/inherit/rich.json", "productdefine/common/inherit/chipset_common.json" ],
+   "subsystems": [
+```
+
+### Configuring Kanto for Backend Connection
+Adjust the Kanto configuration by editing the file at `//third_party/kanto/init/config.json`. This setup is crucial for linking your device with a Kanto backend. For instance, if you're utilizing the Eclipse Hono sandbox, your `config.json` could be structured as follows:
+```json
+{
+    "caCert": "/etc/suite-connector/iothub.crt",
+    "provisioningFile": "/etc/suite-connector/provisioning.json",
+    "logFile": "/data/log/kanto/suite-connector.log",
+    "address":"mqtts://hono.eclipseprojects.io:8883",
+    "tenantId":"demo",
+    "deviceId":"demo:device",
+    "authId":"demo_device",
+    "password":"secret"
+}
+```
+
+### Building Docker Image
+Construct a new Docker image. This step uses the Dockerfile that, starting from the OpenHarmony Docker image, incorporates the necessary Golang environment for building the Kanto suite connector:
+
 
 ```console
 docker build -t docker_oniro ./third_party/kanto
 ```
 
-- run the newly built docker image to build Oniro with kanto integrated
+Execute the newly built Docker image and utilize it to build Oniro-OpenHarmony with the Kanto integration:
 
 ```console
 docker run -it -v $(pwd):/home/openharmony docker_oniro
 ```
 
-- Inside the Docker instance, set the target device for the build
+Inside the Docker instance, set the target device for the build process with the provided command.
 
 ```console
 ./build.sh --product-name rk3568 --ccache
 ```
 
-- You will find the build artifacts such as `suite-connector` binary
-in the directory `//out/rk3568/obj/third_party/kanto`
+## Deploying and Starting the Board
+After completing the build, proceed to flash the board as directed in the documentation. Upon booting, Kanto and Mosquitto services will initiate automatically, streamlining the startup process.
+
+### Useful Tips:
+- Log files for Kanto and Mosquitto can be found at `/data/log/kanto/suite-connector.log` and `/data/log/mosquitto/mosquitto.log`, respectively. These logs are instrumental for troubleshooting and monitoring service activity.
+- For manual control over the services, employ the `service_control` command, specifying either `kanto` or `mosquitto` to start or stop the services as needed.
+- An active internet connection is necessary for the suite-connector to communicate with the backend. You may need to configure a Wi-Fi connection on your device to ensure uninterrupted data upload capabilities.
+
+## Conclusion
+Following these steps will successfully integrate Kanto and Mosquitto into your Oniro-OpenHarmony build system, allowing you to leverage these third-party services within your projects. This integration enhances the system's functionality, offering a more robust and versatile development environment.

--- a/bundle.json
+++ b/bundle.json
@@ -28,7 +28,8 @@
         "build": {
             "sub_component": [
                 "//third_party/kanto:suite-connector",
-                "//third_party/kanto:iothub-crt"
+                "//third_party/kanto:iothub-crt",
+                "//third_party/kanto:kanto_init"
             ],
             "inner_kits": [],
             "test": []

--- a/bundle.json
+++ b/bundle.json
@@ -1,0 +1,37 @@
+{
+    "name": "@ohos/kanto",
+    "description": "kanto",
+    "version": "1.0",
+    "license": "Apache V2",
+    "publishAs": "code-segment",
+    "segment": {
+        "destPath": "third_party/kanto"
+    },
+    "dirs": {},
+    "scripts": {},
+    "licensePath": "LICENSE",
+    "readmePath": {
+        "en": "README.md"
+    },
+    "component": {
+        "name": "kanto",
+        "subsystem": "thirdparty",
+        "syscap": [],
+        "features": [],
+        "adapted_system_type": [],
+        "rom": "",
+        "ram": "",
+        "deps": {
+            "components": [],
+            "third_party": []
+        },
+        "build": {
+            "sub_component": [
+                "//third_party/kanto:suite-connector",
+                "//third_party/kanto:iothub-crt"
+            ],
+            "inner_kits": [],
+            "test": []
+        }
+    }
+}

--- a/init/config.json
+++ b/init/config.json
@@ -1,5 +1,5 @@
 {
     "caCert": "/etc/suite-connector/iothub.crt",
     "provisioningFile": "/etc/suite-connector/provisioning.json",
-    "logFile": "/data/log/suite-connector.log"
+    "logFile": "/data/log/kanto/suite-connector.log"
 }

--- a/init/config.json
+++ b/init/config.json
@@ -1,0 +1,5 @@
+{
+    "caCert": "/etc/suite-connector/iothub.crt",
+    "provisioningFile": "/etc/suite-connector/provisioning.json",
+    "logFile": "/data/log/suite-connector.log"
+}

--- a/init/hosts
+++ b/init/hosts
@@ -1,0 +1,2 @@
+127.0.0.1    localhost
+::1          localhost

--- a/init/kanto.cfg
+++ b/init/kanto.cfg
@@ -1,0 +1,10 @@
+{
+    "services": [
+        {
+            "name": "kanto",
+            "path": ["/system/bin/suite-connector", "-configFile", "/etc/suite-connector/config.json"],
+            "uid": "mosquitto",
+            "gid": ["mosquitto"]
+        }
+    ]
+}

--- a/init/kanto.cfg
+++ b/init/kanto.cfg
@@ -1,4 +1,12 @@
 {
+    "jobs" : [{
+            "name" : "init",
+            "cmds" : [
+                "mkdir /data/log 0775 system log",
+                "mkdir /data/log/kanto 0750 mosquitto log"
+            ]
+        }
+    ],
     "services": [
         {
             "name": "kanto",

--- a/init/kanto.cfg
+++ b/init/kanto.cfg
@@ -11,8 +11,9 @@
         {
             "name": "kanto",
             "path": ["/system/bin/suite-connector", "-configFile", "/etc/suite-connector/config.json"],
-            "uid": "mosquitto",
-            "gid": ["mosquitto"]
+            "uid": "kanto",
+            "gid": ["kanto"],
+            "secon" : "u:r:kanto:s0"
         }
     ]
 }

--- a/ohos_policy-add-selinux-policy.patch
+++ b/ohos_policy-add-selinux-policy.patch
@@ -1,0 +1,249 @@
+From 521c6a63387b24a3d79184f49e112ea58cb94939 Mon Sep 17 00:00:00 2001
+From: Francesco Pham <francesco.pham@huawei.com>
+Date: Mon, 4 Mar 2024 14:12:04 +0100
+Subject: [PATCH] ohos_policy: Add selinux policy for kanto and mosquitto
+ services
+
+some selinux policy are needed for kanto and mosquitto services to properly run.
+
+Related issue: https://gitlab.eclipse.org/eclipse/oniro-core/ohos-planning/-/issues/41
+Related issue: https://gitlab.eclipse.org/eclipse/oniro-core/ohos-planning/-/issues/47
+---
+ sepolicy/ohos_policy/kanto/public/kanto.te    | 21 +++++++++++
+ .../ohos_policy/kanto/system/file_contexts    | 17 +++++++++
+ sepolicy/ohos_policy/kanto/system/init.te     | 16 +++++++++
+ sepolicy/ohos_policy/kanto/system/kanto.te    | 25 +++++++++++++
+ .../ohos_policy/mosquitto/public/mosquitto.te | 21 +++++++++++
+ .../mosquitto/system/file_contexts            | 17 +++++++++
+ sepolicy/ohos_policy/mosquitto/system/init.te | 16 +++++++++
+ .../ohos_policy/mosquitto/system/mosquitto.te | 36 +++++++++++++++++++
+ 8 files changed, 169 insertions(+)
+ create mode 100644 sepolicy/ohos_policy/kanto/public/kanto.te
+ create mode 100644 sepolicy/ohos_policy/kanto/system/file_contexts
+ create mode 100644 sepolicy/ohos_policy/kanto/system/init.te
+ create mode 100644 sepolicy/ohos_policy/kanto/system/kanto.te
+ create mode 100644 sepolicy/ohos_policy/mosquitto/public/mosquitto.te
+ create mode 100644 sepolicy/ohos_policy/mosquitto/system/file_contexts
+ create mode 100644 sepolicy/ohos_policy/mosquitto/system/init.te
+ create mode 100644 sepolicy/ohos_policy/mosquitto/system/mosquitto.te
+
+diff --git a/sepolicy/ohos_policy/kanto/public/kanto.te b/sepolicy/ohos_policy/kanto/public/kanto.te
+new file mode 100644
+index 00000000..25944902
+--- /dev/null
++++ b/sepolicy/ohos_policy/kanto/public/kanto.te
+@@ -0,0 +1,21 @@
++# Copyright (c) 2022-2023 Huawei Device Co., Ltd.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++##################
++## Type define: ##
++##################
++type kanto, sadomain, domain;
++
++type kanto_exec, exec_attr, file_attr, system_file_attr;
++type data_kanto_file, file_attr, data_file_attr;
++init_daemon_domain(kanto);
+diff --git a/sepolicy/ohos_policy/kanto/system/file_contexts b/sepolicy/ohos_policy/kanto/system/file_contexts
+new file mode 100644
+index 00000000..e58a652b
+--- /dev/null
++++ b/sepolicy/ohos_policy/kanto/system/file_contexts
+@@ -0,0 +1,17 @@
++# Copyright (c) 2022 Huawei Device Co., Ltd.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++/system/bin/suite-connector              u:object_r:kanto_exec:s0
++
++/data/log/kanto(/.*)?           u:object_r:data_kanto_file:s0
++
+diff --git a/sepolicy/ohos_policy/kanto/system/init.te b/sepolicy/ohos_policy/kanto/system/init.te
+new file mode 100644
+index 00000000..7bb06a8e
+--- /dev/null
++++ b/sepolicy/ohos_policy/kanto/system/init.te
+@@ -0,0 +1,16 @@
++# Copyright (c) 2022 Huawei Device Co., Ltd.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++allow init kanto:file { getattr open read relabelto setattr };
++allow init kanto:dir { getattr open read relabelto setattr search };
++allow init kanto:process { getattr rlimitinh siginh transition };
+diff --git a/sepolicy/ohos_policy/kanto/system/kanto.te b/sepolicy/ohos_policy/kanto/system/kanto.te
+new file mode 100644
+index 00000000..5a247eda
+--- /dev/null
++++ b/sepolicy/ohos_policy/kanto/system/kanto.te
+@@ -0,0 +1,25 @@
++# Copyright (c) 2022-2023 Huawei Device Co., Ltd.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++allow kanto dev_console_file:chr_file  { read write };
++allow kanto debug_param:file { map open read };
++allow kanto kanto:tcp_socket { create setopt bind listen connect getopt getattr write read };
++allow kanto port:tcp_socket { name_bind name_connect };
++allow kanto node:tcp_socket { node_bind };
++allow kanto kanto:udp_socket { create setopt connect getattr write read };
++allow kanto hilog_param:file { map open read };
++allow kanto dev_unix_socket:dir { search };
++allow kanto data_file:dir { search };
++allow kanto data_log:file { read write create append open ioctl getattr };
++allow kanto data_log:dir { write add_name };
++allow kanto system_etc_file:dir { watch };
+diff --git a/sepolicy/ohos_policy/mosquitto/public/mosquitto.te b/sepolicy/ohos_policy/mosquitto/public/mosquitto.te
+new file mode 100644
+index 00000000..23484355
+--- /dev/null
++++ b/sepolicy/ohos_policy/mosquitto/public/mosquitto.te
+@@ -0,0 +1,21 @@
++# Copyright (c) 2022-2023 Huawei Device Co., Ltd.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++##################
++## Type define: ##
++##################
++type mosquitto, sadomain, domain;
++
++type mosquitto_exec, exec_attr, file_attr, system_file_attr;
++type data_mosquitto_file, file_attr, data_file_attr;
++init_daemon_domain(mosquitto);
+diff --git a/sepolicy/ohos_policy/mosquitto/system/file_contexts b/sepolicy/ohos_policy/mosquitto/system/file_contexts
+new file mode 100644
+index 00000000..a84ec086
+--- /dev/null
++++ b/sepolicy/ohos_policy/mosquitto/system/file_contexts
+@@ -0,0 +1,17 @@
++# Copyright (c) 2022 Huawei Device Co., Ltd.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++/system/bin/mosquitto              u:object_r:mosquitto_exec:s0
++
++/data/log/mosquitto(/.*)?           u:object_r:data_mosquitto_file:s0
++
+diff --git a/sepolicy/ohos_policy/mosquitto/system/init.te b/sepolicy/ohos_policy/mosquitto/system/init.te
+new file mode 100644
+index 00000000..e6940ad8
+--- /dev/null
++++ b/sepolicy/ohos_policy/mosquitto/system/init.te
+@@ -0,0 +1,16 @@
++# Copyright (c) 2022 Huawei Device Co., Ltd.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++allow init mosquitto:file { getattr open read relabelto setattr };
++allow init mosquitto:dir { getattr open read relabelto setattr search };
++allow init mosquitto:process { getattr rlimitinh siginh transition };
+diff --git a/sepolicy/ohos_policy/mosquitto/system/mosquitto.te b/sepolicy/ohos_policy/mosquitto/system/mosquitto.te
+new file mode 100644
+index 00000000..9dd84f49
+--- /dev/null
++++ b/sepolicy/ohos_policy/mosquitto/system/mosquitto.te
+@@ -0,0 +1,36 @@
++# Copyright (c) 2022-2023 Huawei Device Co., Ltd.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++# avc:  denied  { read write } for  pid=1690 comm="mosquitto" path="/dev/console" dev="tmpfs" ino=40 scontext=u:r:mosquitto:s0 tcontext=u:object_r:dev_console_file:s0 tclass=chr_file permissive=0
++allow mosquitto dev_console_file:chr_file  { read write };
++
++# avc:  denied  { read } for  pid=1690 comm="mosquitto" name="u:object_r:debug_param:s0" dev="tmpfs" ino=73 scontext=u:r:mosquitto:s0 tcontext=u:object_r:debug_param:s0 tclass=file permissive=0
++allow mosquitto debug_param:file { map open read };
++
++# avc:  denied  { create } for  pid=1648 comm="mosquitto" scontext=u:r:mosquitto:s0 tcontext=u:r:mosquitto:s0 tclass=tcp_socket permissive=0
++allow mosquitto mosquitto:tcp_socket { create setopt bind listen accept getattr read write };
++allow mosquitto port:tcp_socket { name_bind };
++allow mosquitto node:tcp_socket { node_bind };
++
++# avc:  denied  { read } for  pid=1648 comm="mosquitto" name="u:object_r:hilog_param:s0" dev="tmpfs" ino=69 scontext=u:r:mosquitto:s0 tcontext=u:object_r:hilog_param:s0 tclass=file permissive=0
++allow mosquitto hilog_param:file { map open read };
++
++# avc:  denied  { search } for  pid=1648 comm="mosquitto" name="socket" dev="tmpfs" ino=43 scontext=u:r:mosquitto:s0 tcontext=u:object_r:dev_unix_socket:s0 tclass=dir permissive=0
++allow mosquitto dev_unix_socket:dir { search };
++
++# avc:  denied  { search } for  pid=1621 comm="mosquitto" name="/" dev="mmcblk0p14" ino=3 scontext=u:r:mosquitto:s0 tcontext=u:object_r:data_file:s0 tclass=dir permissive=0
++allow mosquitto data_file:dir { search };
++
++# avc:  denied  { write } for  pid=1714 comm="mosquitto" name="mosquitto" dev="mmcblk0p14" ino=23 scontext=u:r:mosquitto:s0 tcontext=u:object_r:data_log:s0 tclass=dir permissive=0
++allow mosquitto data_log:file { read write create append open ioctl getattr };
++allow mosquitto data_log:dir { write add_name };
+-- 
+2.25.1
+


### PR DESCRIPTION
- add Kanto suite-connector as git submodule
- add build scripts and build metadata to build Kanto suite-connector in the OpenHarmony build system
- add README
- add service to start kanto at system startup